### PR TITLE
fix: build the project on Linux

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     "@babel/preset-env",
-    "@babel/preset-TypeScript"
+    "@babel/preset-typescript"
   ],
   "plugins": [
     "@babel/proposal-class-properties",


### PR DESCRIPTION
This prevents build errors on Linux distros since they don't use a case insensitive filesystem.